### PR TITLE
Add Eventbrite registration to upcoming minishops

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,9 +21,10 @@
 ## Post-MVP
 
 - [ ] Write blog post on `npx kill-port` (#TIL)
-- [ ] More #TIL blog posts (back-date from twitter)
 - [ ] Upcoming minishops in blog post footer
   - [ ] Upcoming minishops on non-active minishop pages
+- [ ] Add bugsnag
+- [ ] More #TIL blog posts (back-date from twitter)
 - [ ] Add Contact page (like https://www.sarasoueidan.com/contact/ or https://kentcdodds.com/contact)
 - [ ] Interactive bio / press kit (like https://chriscoyier.net/ or https://www.sarasoueidan.com/press-kit/)
   - [ ] Hi-res photos page (like https://chriscoyier.net/photos/)

--- a/TODO.md
+++ b/TODO.md
@@ -11,11 +11,11 @@
   - [x] Add minishops home page (using tagline)
     - Let's learn together without having to leave your house!
   - [x] Write blog post about minishops
-- [ ] Create Eventbrite event for a minishop
-  - [ ] Add schema.org (+ events SMO)
-  - [ ] Upcoming minishops on home page ("Develop")
-  - [ ] Display upcoming minishops at the top of home page
-  - [ ] Add hidden "skip navigation" in header
+- [x] Create Eventbrite event for a minishop
+  - [x] Add schema.org (+ events SMO)
+  - [x] Upcoming minishops on home page ("Develop")
+  - [x] Display upcoming minishops at the top of minishops page
+  - [x] Add hidden "skip navigation" in header
 - [x] Pull out fragments into separate file
 
 ## Post-MVP
@@ -23,6 +23,7 @@
 - [ ] Write blog post on `npx kill-port` (#TIL)
 - [ ] More #TIL blog posts (back-date from twitter)
 - [ ] Upcoming minishops in blog post footer
+  - [ ] Upcoming minishops on non-active minishop pages
 - [ ] Add Contact page (like https://www.sarasoueidan.com/contact/ or https://kentcdodds.com/contact)
 - [ ] Interactive bio / press kit (like https://chriscoyier.net/ or https://www.sarasoueidan.com/press-kit/)
   - [ ] Hi-res photos page (like https://chriscoyier.net/photos/)

--- a/content/minishops/typescript-for-react-developers/index.md
+++ b/content/minishops/typescript-for-react-developers/index.md
@@ -7,6 +7,9 @@ tags: [react, typescript, hooks, generics]
 hero: ./home-office-caspar-camille-rubin-0qvBNep1Y04-unsplash.jpg
 heroAlt: A photo of a home office with a super-wide monitor w/ code on it
 heroCredit: 'Photo by [Caspar Camille Rubin](https://unsplash.com/@casparrubin)'
+event:
+  id: '106686762980'
+  start: 2020-06-25T09:00:00-07:00
 ---
 
 TypeScript is a JavaScript superset that compiles down to vanilla JavaScript and has become increasingly popular. TypeScript offers strong typing and compile-time verification to our React applications. As a result, using TypeScript helps eliminate entire classes of bugs that commonly affect our apps.

--- a/content/minishops/typescript-for-react-developers/index.md
+++ b/content/minishops/typescript-for-react-developers/index.md
@@ -10,6 +10,7 @@ heroCredit: 'Photo by [Caspar Camille Rubin](https://unsplash.com/@casparrubin)'
 event:
   id: '106686762980'
   start: 2020-06-25T09:00:00-07:00
+  end: 2020-06-25T12:00:00-07:00
 ---
 
 TypeScript is a JavaScript superset that compiles down to vanilla JavaScript and has become increasingly popular. TypeScript offers strong typing and compile-time verification to our React applications. As a result, using TypeScript helps eliminate entire classes of bugs that commonly affect our apps.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -92,7 +92,6 @@ module.exports = {
         showSpinner: false,
       },
     },
-    'gatsby-plugin-netlify-cache',
     {
       resolve: 'gatsby-plugin-feed',
       options: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "public/"
 
+[[plugins]]
+  package = "netlify-plugin-gatsby-cache"
+
 # Redirects for removed pages
 [[redirects]]
   from = "/talks/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
   command = "npm run build"
   publish = "public/"
 
-[[plugins]]
-  package = "netlify-plugin-no-more-404"
-
 # Redirects for removed pages
 [[redirects]]
   from = "/talks/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,6 @@
   publish = "public/"
 
 [[plugins]]
-  package = "netlify-plugin-gatsby-cache"
-[[plugins]]
   package = "netlify-plugin-no-more-404"
 
 # Redirects for removed pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -6790,6 +6790,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.12.0.tgz",
       "integrity": "sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw=="
     },
+    "date-fns-tz": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.0.10.tgz",
+      "integrity": "sha512-cHQAz0/9uDABaUNDM80Mj1FL4ODlxs1xEY4b0DQuAooO2UdNKvDkNbV8ogLnxLbv02Ru1HXFcot0pVvDRBgptg=="
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10379,27 +10379,6 @@
         "postcss": "^7.0.17"
       }
     },
-    "gatsby-plugin-netlify-cache": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.2.0.tgz",
-      "integrity": "sha512-unt4mAVpC0JzwZSo8KQV4P/trDHkr3PeTWDF5Hijw9jGfNQIWXbcj9nYljAVg7HCich6E6b27Q+zuf53InwpDQ==",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "fs-extra": "^7.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
-      }
-    },
     "gatsby-plugin-nprogress": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-nprogress/-/gatsby-plugin-nprogress-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@material-ui/icons": "^4.9.1",
     "classnames": "^2.2.6",
     "date-fns": "^2.12.0",
+    "date-fns-tz": "^1.0.10",
     "dotenv": "^8.2.0",
     "gatsby": "^2.21.9",
     "gatsby-image": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "benmvp.com",
   "scripts": {
-    "build": "gatsby build --log-pages",
+    "build": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "benmvp.com",
   "scripts": {
-    "build": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
+    "build": "gatsby build --log-pages",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
@@ -29,7 +29,6 @@
     "gatsby-plugin-feed": "^2.5.0",
     "gatsby-plugin-google-analytics": "^2.3.0",
     "gatsby-plugin-manifest": "^2.4.1",
-    "gatsby-plugin-netlify-cache": "^1.2.0",
     "gatsby-plugin-nprogress": "^2.3.0",
     "gatsby-plugin-offline": "^3.2.0",
     "gatsby-plugin-react-helmet": "^3.3.0",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,32 +18,22 @@ import Footer from './Footer'
 import Masthead from './Masthead'
 import { getTheme } from '../../config/theme'
 
-const useStyles = makeStyles((theme) =>
+interface ScrollToTopProps {
+  children: ReactNode
+}
+
+const useScrollToTopStyles = makeStyles((theme) =>
   createStyles({
-    root: {
-      backgroundColor: theme.palette.background.default,
-    },
-    container: {
-      minHeight: ({ masthead }) => (masthead ? undefined : '100vh'),
-      marginTop: ({ masthead }) => (masthead ? undefined : theme.spacing(2)),
-    },
     toTop: {
       position: 'fixed',
       bottom: theme.spacing(2),
       right: theme.spacing(2),
     },
-    backToTopAnchor: {
-      height: 82,
-    },
   }),
 )
 
-interface ScrollToTopProps {
-  children: ReactNode
-}
-
 const ScrollToTop = ({ children }: ScrollToTopProps) => {
-  const classes = useStyles()
+  const classes = useScrollToTopStyles()
   const trigger = useScrollTrigger({
     disableHysteresis: true,
     threshold: 100,
@@ -74,8 +64,38 @@ interface Props {
   maxWidth?: 'md' | 'lg'
 }
 
-const Layout = ({ children, masthead = false, maxWidth = 'md' }: Props) => {
-  const classes = useStyles()
+const useMainStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      backgroundColor: theme.palette.background.default,
+    },
+    skipNav: {
+      position: 'absolute',
+      left: -10000,
+      top: 'auto',
+      width: 1,
+      height: 1,
+      overflow: 'hidden',
+    },
+    container: {
+      minHeight: ({ masthead }: Props) => (masthead ? undefined : '100vh'),
+      marginTop: ({ masthead }: Props) =>
+        masthead ? undefined : theme.spacing(2),
+    },
+    toTop: {
+      position: 'fixed',
+      bottom: theme.spacing(2),
+      right: theme.spacing(2),
+    },
+    backToTopAnchor: {
+      height: 82,
+    },
+  }),
+)
+
+const Layout = (props: Props) => {
+  const classes = useMainStyles(props)
+  const { children, masthead = false, maxWidth = 'md' } = props
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)')
   const theme = useMemo(() => getTheme(prefersDarkMode), [prefersDarkMode])
 
@@ -84,6 +104,9 @@ const Layout = ({ children, masthead = false, maxWidth = 'md' }: Props) => {
       <CssBaseline />
       <ThemeProvider theme={theme}>
         <Box component="section" className={classes.root}>
+          <a href="#skip-heading" className={classes.skipNav}>
+            Skip Main Navigation
+          </a>
           <Header />
           <Toolbar
             id="back-to-top-anchor"
@@ -91,7 +114,11 @@ const Layout = ({ children, masthead = false, maxWidth = 'md' }: Props) => {
           />
 
           {masthead && <Masthead />}
-          <Container maxWidth={maxWidth} className={classes.container}>
+          <Container
+            id="skip-heading"
+            maxWidth={maxWidth}
+            className={classes.container}
+          >
             <Box component="main">{children}</Box>
           </Container>
           <Footer />

--- a/src/components/MinishopCard.tsx
+++ b/src/components/MinishopCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import formatDate from 'date-fns-tz/format'
 import {
   makeStyles,
   createStyles,
@@ -16,6 +17,10 @@ import { getMinishopUrl, genMinishopSlug } from '../utils'
 import useCopyUrl from '../utils/useCopyUrl'
 
 interface Props {
+  event: {
+    id: string
+    start: string
+  }
   mode?: 'min' | 'full'
   slug: string
   summary: string
@@ -32,11 +37,27 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-const MinishopCard = ({ mode = 'full', slug, summary, tags, title }: Props) => {
+const MinishopCard = ({
+  event,
+  mode = 'full',
+  slug,
+  summary,
+  tags,
+  title,
+}: Props) => {
   const classes = useStyles()
   const url = getMinishopUrl(slug)
   const [{ copyText, copyButtonColor }, copy] = useCopyUrl(url)
   const showShare = mode !== 'min'
+  let fullDate
+
+  if (event?.start) {
+    const startDate = Date.parse(event.start)
+    const formattedDate = formatDate(startDate, 'EEEE, MMMM d, yyyy')
+    const formattedTime = formatDate(startDate, 'h:mm b z')
+
+    fullDate = `${formattedDate} @ ${formattedTime}`
+  }
 
   return (
     <Card id={genMinishopSlug(title)}>
@@ -46,6 +67,18 @@ const MinishopCard = ({ mode = 'full', slug, summary, tags, title }: Props) => {
         underline="none"
       >
         <CardContent>
+          {fullDate && (
+            <Typography
+              gutterBottom
+              variant="subtitle2"
+              color="textSecondary"
+              component="h4"
+              title={fullDate}
+              noWrap
+            >
+              {fullDate}
+            </Typography>
+          )}
           <Typography
             gutterBottom
             variant="h5"

--- a/src/components/MinishopRegister.tsx
+++ b/src/components/MinishopRegister.tsx
@@ -8,7 +8,6 @@ import {
   Paper,
   Typography,
 } from '@material-ui/core'
-import Helmet from 'react-helmet'
 
 interface Props {
   event: {
@@ -37,12 +36,40 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
   const buttonId = `eventbrite-checkout-${event.id}-${isTop ? 'top' : 'bottom'}`
 
   useEffect(() => {
-    window.EBWidgets?.createWidget({
-      widgetType: 'checkout',
-      eventId: event.id,
-      modal: true,
-      modalTriggerElementId: buttonId,
-    })
+    const createWidget = () => {
+      window.EBWidgets?.createWidget({
+        widgetType: 'checkout',
+        eventId: event.id,
+        modal: true,
+        modalTriggerElementId: buttonId,
+      })
+    }
+
+    let widgetsScript = document.getElementById('eb_widgets')
+
+    // create the widgets script if it doesn't already exists
+    if (!widgetsScript) {
+      widgetsScript = document.createElement('script')
+
+      widgetsScript.id = 'eb_widgets'
+      widgetsScript.async = true
+      widgetsScript.src =
+        'https://www.eventbrite.com/static/widgets/eb_widgets.js'
+      widgetsScript.type = 'text/javascript'
+
+      document.body.appendChild(widgetsScript)
+    }
+
+    // notify when it's finally loaded
+    widgetsScript?.addEventListener('load', createWidget)
+
+    return () => {
+      widgetsScript?.removeEventListener('load', createWidget)
+
+      if (widgetsScript) {
+        document.body.removeChild(widgetsScript)
+      }
+    }
   }, [event, buttonId])
 
   return (
@@ -68,21 +95,17 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
             </Typography>
           </Box>
           <Box>
-            <Button variant="contained" color="secondary" id={buttonId}>
+            <Button
+              variant="contained"
+              color="secondary"
+              id={buttonId}
+              href={`https://www.eventbrite.com/e/${event.id}`}
+            >
               Register now
             </Button>
           </Box>
         </Box>
       </Paper>
-
-      <Helmet>
-        {isTop && (
-          <script
-            src="https://www.eventbrite.com/static/widgets/eb_widgets.js"
-            type="text/javascript"
-          />
-        )}
-      </Helmet>
     </>
   )
 }

--- a/src/components/MinishopRegister.tsx
+++ b/src/components/MinishopRegister.tsx
@@ -20,7 +20,7 @@ interface Props {
 const useStyles = makeStyles((theme) =>
   createStyles({
     root: {
-      margin: theme.spacing(5, 0),
+      margin: theme.spacing(5, 0, 1),
       padding: theme.spacing(2),
       backgroundColor: theme.palette.secondary.main,
       color: theme.palette.secondary.contrastText,
@@ -90,9 +90,9 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
             textAlign={{ xs: 'center', sm: 'left' }}
           >
             <Typography variant="h6" component="h3">
-              Next Minishop
+              Next Online Minishop*
             </Typography>
-            <Typography variant="h5" component="span">
+            <Typography variant="h5" component="p">
               {formattedDate} @ {formattedTime}
             </Typography>
           </Box>
@@ -108,6 +108,11 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
           </Box>
         </Box>
       </Paper>
+      <Box textAlign={{ xs: 'center', sm: 'left' }} mb={5}>
+        <Typography variant="caption" component="p">
+          * You will receive a link to the Zoom meeting the night before
+        </Typography>
+      </Box>
     </>
   )
 }

--- a/src/components/MinishopRegister.tsx
+++ b/src/components/MinishopRegister.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import formatDate from 'date-fns-tz/format'
 import {
   makeStyles,
@@ -36,12 +36,14 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
   const formattedTime = formatDate(startDate, 'h:mm b z')
   const buttonId = `eventbrite-checkout-${event.id}-${isTop ? 'top' : 'bottom'}`
 
-  const widgetProperties = {
-    widgetType: 'checkout',
-    eventId: event.id,
-    modal: true,
-    modalTriggerElementId: buttonId,
-  }
+  useEffect(() => {
+    window.EBWidgets?.createWidget({
+      widgetType: 'checkout',
+      eventId: event.id,
+      modal: true,
+      modalTriggerElementId: buttonId,
+    })
+  }, [event, buttonId])
 
   return (
     <>
@@ -81,9 +83,6 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
           />
         )}
       </Helmet>
-      <script type="text/javascript">
-        {`window.EBWidgets.createWidget(${JSON.stringify(widgetProperties)});`}
-      </script>
     </>
   )
 }

--- a/src/components/MinishopRegister.tsx
+++ b/src/components/MinishopRegister.tsx
@@ -22,8 +22,8 @@ const useStyles = makeStyles((theme) =>
     root: {
       margin: theme.spacing(5, 0),
       padding: theme.spacing(2),
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.primary.contrastText,
+      backgroundColor: theme.palette.secondary.main,
+      color: theme.palette.secondary.contrastText,
     },
   }),
 )
@@ -46,6 +46,7 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
     }
 
     let widgetsScript = document.getElementById('eb_widgets')
+    let added = false
 
     // create the widgets script if it doesn't already exists
     if (!widgetsScript) {
@@ -58,6 +59,7 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
       widgetsScript.type = 'text/javascript'
 
       document.body.appendChild(widgetsScript)
+      added = true
     }
 
     // notify when it's finally loaded
@@ -66,7 +68,7 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
     return () => {
       widgetsScript?.removeEventListener('load', createWidget)
 
-      if (widgetsScript) {
+      if (widgetsScript && added) {
         document.body.removeChild(widgetsScript)
       }
     }
@@ -97,9 +99,9 @@ const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
           <Box>
             <Button
               variant="contained"
-              color="secondary"
+              color="primary"
+              size="large"
               id={buttonId}
-              href={`https://www.eventbrite.com/e/${event.id}`}
             >
               Register now
             </Button>

--- a/src/components/MinishopRegister.tsx
+++ b/src/components/MinishopRegister.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import formatDate from 'date-fns-tz/format'
+import {
+  makeStyles,
+  createStyles,
+  Box,
+  Button,
+  Paper,
+  Typography,
+} from '@material-ui/core'
+import Helmet from 'react-helmet'
+
+interface Props {
+  event: {
+    id: string
+    start: string
+  }
+  isTop?: boolean
+}
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    root: {
+      margin: theme.spacing(5, 0),
+      padding: theme.spacing(2),
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+    },
+  }),
+)
+
+const MinishopRegister = ({ event, isTop: isTop = false }: Props) => {
+  const classes = useStyles()
+  const startDate = Date.parse(event.start)
+  const formattedDate = formatDate(startDate, 'EEEE, MMMM d, yyyy')
+  const formattedTime = formatDate(startDate, 'h:mm b z')
+  const buttonId = `eventbrite-checkout-${event.id}-${isTop ? 'top' : 'bottom'}`
+
+  const widgetProperties = {
+    widgetType: 'checkout',
+    eventId: event.id,
+    modal: true,
+    modalTriggerElementId: buttonId,
+  }
+
+  return (
+    <>
+      <Paper component="section" elevation={3} className={classes.root}>
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          flexDirection={{ xs: 'column', sm: 'row' }}
+        >
+          <Box
+            mr={{ xs: 0, sm: 2 }}
+            mb={{ xs: 2, sm: 0 }}
+            flex={1}
+            textAlign={{ xs: 'center', sm: 'left' }}
+          >
+            <Typography variant="h6" component="h3">
+              Next Minishop
+            </Typography>
+            <Typography variant="h5" component="span">
+              {formattedDate} @ {formattedTime}
+            </Typography>
+          </Box>
+          <Box>
+            <Button variant="contained" color="secondary" id={buttonId}>
+              Register now
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+
+      <Helmet>
+        {isTop && (
+          <script
+            src="https://www.eventbrite.com/static/widgets/eb_widgets.js"
+            type="text/javascript"
+          />
+        )}
+      </Helmet>
+      <script type="text/javascript">
+        {`window.EBWidgets.createWidget(${JSON.stringify(widgetProperties)});`}
+      </script>
+    </>
+  )
+}
+
+export default MinishopRegister

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -151,7 +151,7 @@ export default ({ data }) => {
           gutterBottom
           aria-label="Join one of Ben's upcoming minishops"
         >
-          Develop...
+          Develop
         </Typography>
         <MinishopCardList
           minishops={upcomingMinishops.edges.filter(
@@ -167,7 +167,7 @@ export default ({ data }) => {
           gutterBottom
           aria-label="Attend one of Ben's future tech talks"
         >
-          Attend...
+          Attend
         </Typography>
         <SpeakCardList />
       </Box>
@@ -179,7 +179,7 @@ export default ({ data }) => {
           gutterBottom
           aria-label="Read one of Ben's recent blog posts"
         >
-          Read...
+          Read
         </Typography>
         <PostCardList posts={recentPosts.edges} />
       </Box>
@@ -191,7 +191,7 @@ export default ({ data }) => {
           gutterBottom
           aria-label="Watch Ben's most recent tech talk video"
         >
-          Watch...
+          Watch
         </Typography>
         <VideoCardList />
       </Box>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme) =>
 const MinishopCardList = ({ minishops }) => (
   <Grid container spacing={2}>
     {minishops.map(({ node }) => (
-      <Grid key={node.id} item xs={12} sm={6}>
+      <Grid key={node.id} item xs={12} lg={6}>
         <MinishopCard
           mode="min"
           slug={node.fields.slug}

--- a/src/pages/minishops.tsx
+++ b/src/pages/minishops.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { graphql } from 'gatsby'
-import { createStyles, makeStyles, Typography, Grid } from '@material-ui/core'
+import {
+  createStyles,
+  makeStyles,
+  Typography,
+  Grid,
+  Divider,
+} from '@material-ui/core'
 import Layout from '../components/Layout'
 import Seo from '../components/Seo'
 import PageHeader from '../components/PageHeader'
@@ -19,12 +25,22 @@ const useStyles = makeStyles((theme) =>
     grid: {
       marginTop: theme.spacing(3),
     },
+    divider: {
+      margin: theme.spacing(5, 'auto'),
+      width: '50%',
+    },
   }),
 )
 
 const SpeakingEngagements = ({ data }) => {
   const classes = useStyles()
   const { hero, minishops } = data
+  const upcomingMinishops = minishops.edges.filter(
+    ({ node }) => node.frontmatter.event?.start,
+  )
+  const remainingMinishops = minishops.edges.filter(
+    ({ node }) => !node.frontmatter.event?.start,
+  )
 
   return (
     <Layout>
@@ -45,17 +61,39 @@ const SpeakingEngagements = ({ data }) => {
         credit="Photo by [Tudor Baciu](https://unsplash.com/@baciutudor)"
         className={classes.image}
       />
+      {upcomingMinishops.length && (
+        <>
+          <Typography component="h3" variant="h4">
+            Upcoming Minishops
+          </Typography>
+          <Grid container spacing={2} className={classes.grid}>
+            {upcomingMinishops.map(({ node }) => (
+              <Grid key={node.id} item xs={12} sm={6}>
+                <MinishopCard
+                  slug={node.fields.slug}
+                  title={node.frontmatter.title}
+                  tags={node.frontmatter.tags}
+                  summary={node.frontmatter.subTitle || node.excerpt}
+                  event={node.frontmatter.event}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          <Divider variant="middle" className={classes.divider} />
+        </>
+      )}
       <Typography component="h3" variant="h4">
         All Minishops
       </Typography>
       <Grid container spacing={2} className={classes.grid}>
-        {minishops.edges.map(({ node }) => (
+        {remainingMinishops.map(({ node }) => (
           <Grid key={node.id} item xs={12} sm={6}>
             <MinishopCard
               slug={node.fields.slug}
               title={node.frontmatter.title}
               tags={node.frontmatter.tags}
               summary={node.frontmatter.subTitle || node.excerpt}
+              event={node.frontmatter.event}
             />
           </Grid>
         ))}
@@ -85,7 +123,7 @@ export const query = graphql`
       edges {
         node {
           id
-          ...PostCardInfo
+          ...MinishopCardInfo
         }
       }
     }

--- a/src/pages/minishops.tsx
+++ b/src/pages/minishops.tsx
@@ -68,7 +68,7 @@ const SpeakingEngagements = ({ data }) => {
           </Typography>
           <Grid container spacing={2} className={classes.grid}>
             {upcomingMinishops.map(({ node }) => (
-              <Grid key={node.id} item xs={12} sm={6}>
+              <Grid key={node.id} item xs={12}>
                 <MinishopCard
                   slug={node.fields.slug}
                   title={node.frontmatter.title}

--- a/src/templates/Minishop.tsx
+++ b/src/templates/Minishop.tsx
@@ -6,6 +6,7 @@ import PageHeader from '../components/PageHeader'
 import HeroImage from '../components/HeroImage'
 import Content from '../components/Content'
 import Seo from '../components/Seo'
+import MinishopRegister from '../components/MinishopRegister'
 import MinishopForm from '../components/MinishopForm'
 import Share from '../components/Share'
 import { getMinishopUrl } from '../utils'
@@ -37,6 +38,7 @@ const Minishop = ({ data }) => {
     hero,
     heroAlt,
     heroCredit,
+    event,
   } = frontmatter
   const { slug } = fields
   const url = getMinishopUrl(slug)
@@ -52,6 +54,10 @@ const Minishop = ({ data }) => {
         image={hero?.childImageSharp?.fluid?.src}
         imageAlt={heroAlt}
         type="events.event"
+        meta={[
+          { property: 'event:start_time', content: event.startDateTime },
+          { property: 'event:end_time', content: event.endDateTime },
+        ]}
         schemaOrg={{
           '@type': 'EducationEvent',
           eventAttendanceMode: 'OnlineEventAttendanceMode',
@@ -59,6 +65,8 @@ const Minishop = ({ data }) => {
           location: {
             '@type': 'VirtualLocation',
           },
+          startDate: event.startDateTime,
+          endDate: event.endDateTime,
           teaches: category,
         }}
       />
@@ -75,7 +83,9 @@ const Minishop = ({ data }) => {
           className={classes.image}
         />
       )}
+      <MinishopRegister event={event} isTop />
       <Content>{html}</Content>
+      <MinishopRegister event={event} />
       <Box component="footer" className={classes.footer}>
         <Share
           url={url}
@@ -83,7 +93,7 @@ const Minishop = ({ data }) => {
           summary={summary}
           tags={tags}
         />
-        <MinishopForm slug={slug} title={title} />
+        {!event && <MinishopForm slug={slug} title={title} />}
       </Box>
     </Layout>
   )
@@ -110,6 +120,10 @@ export const query = graphql`
         }
         heroAlt
         heroCredit
+        event {
+          id
+          start
+        }
       }
     }
   }

--- a/src/templates/Minishop.tsx
+++ b/src/templates/Minishop.tsx
@@ -55,8 +55,12 @@ const Minishop = ({ data }) => {
         imageAlt={heroAlt}
         type="events.event"
         meta={[
-          { property: 'event:start_time', content: event.startDateTime },
-          { property: 'event:end_time', content: event.endDateTime },
+          ...(event
+            ? [
+                { property: 'event:start_time', content: event.start },
+                { property: 'event:end_time', content: event.end },
+              ]
+            : []),
         ]}
         schemaOrg={{
           '@type': 'EducationEvent',
@@ -65,9 +69,13 @@ const Minishop = ({ data }) => {
           location: {
             '@type': 'VirtualLocation',
           },
-          startDate: event.startDateTime,
-          endDate: event.endDateTime,
           teaches: category,
+          ...(event
+            ? {
+                startDate: event.start,
+                endDate: event.end,
+              }
+            : {}),
         }}
       />
       <PageHeader
@@ -83,9 +91,9 @@ const Minishop = ({ data }) => {
           className={classes.image}
         />
       )}
-      <MinishopRegister event={event} isTop />
+      {event && <MinishopRegister event={event} isTop />}
       <Content>{html}</Content>
-      <MinishopRegister event={event} />
+      {event && <MinishopRegister event={event} />}
       <Box component="footer" className={classes.footer}>
         <Share
           url={url}

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -7,6 +7,10 @@ export const fragments = graphql`
       subTitle
       category
       tags
+      event {
+        id
+        start
+      }
     }
     fields {
       slug


### PR DESCRIPTION
## Problem

Need to be able to show Eventbrite checkout widget on the minishop(s) that are active. Also, need to be able to highlight the upcoming minishops on the home page and the minishops page

## Solution

Add `MinishopRegister` component that handles including the button that activates the Eventbrite checkout widget

Also:

- Include upcoming minishops on home and minishops home pages
- Include date/time to minishop card (if exists)
- Include SEO event start/end date info
- Add skip navigation link to page layout