### PR TITLE
Add adsense script to all pages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,8 @@
 - [ ] Speaker rider (like https://github.com/cassidoo/talks/blob/master/speaker-rider.md)
 - [ ] Breadcrumbs (to easily jump to category pages like /minishops/ or /blog/)
 - [ ] Newsletter
+- [x] Google AdSense
+- [ ] Recent blog posts in blog post footer
 
 ## Data-driven features
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, ReactNode } from 'react'
+import Helmet from 'react-helmet'
 import {
   makeStyles,
   createStyles,
@@ -101,6 +102,13 @@ const Layout = (props: Props) => {
 
   return (
     <>
+      <Helmet>
+        <script
+          data-ad-client="ca-pub-8593460861818909"
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+        ></script>
+      </Helmet>
       <CssBaseline />
       <ThemeProvider theme={theme}>
         <Box component="section" className={classes.root}>


### PR DESCRIPTION
## Problem

It'd be nice if we can somehow monetize site traffic.


## Solution

Add [Google Adsense](https://www.google.com/adsense/) to every page. May need to come back and conditionally include it only on the pages I want (like blog posts and minishop pages)

