### PR TITLE
Fix type checking

### DIFF
--- a/content/posts/when-use-typescript-unknown-versus-any/index.md
+++ b/content/posts/when-use-typescript-unknown-versus-any/index.md
@@ -62,7 +62,7 @@ However, if we use type narrowing, like doing `typeof`/`instanceof` checks, comp
 
 ```typescript
 // typeof check
-if (typeof unknownData === 'object') {
+if (unknownData && typeof unknownData === 'object') {
   // ✅ TS knows `data` is an `object`
   // type now
   const dataKeys = Object.keys(unknownData)


### PR DESCRIPTION


## Problem

`unknownData` can still be null since `typeof null === "object"` 

<!-- State the problem the PR is aiming to solve -->


## Solution

We want to make sure `unknownData` is not null before passing it to `Object.keys`

<!--
Outline the solution to the problem.

If this fixes an existing issue include:

Fixes #<ISSUE_NUM>.
-->

