### PR TITLE
Small typo

### DIFF
--- a/content/posts/learn-typescript-generics-rebuilding-existing-utility-types/index.md
+++ b/content/posts/learn-typescript-generics-rebuilding-existing-utility-types/index.md
@@ -36,7 +36,7 @@ interface Team {
 // `fieldsToUpdate` can take any properties of a `Team` since
 // all properties are optional. We don't have to pass in a
 // full `Team` object
-const updateTeam = (team: Team: fieldsToUpdate: Partial<Team>): Team => {
+const updateTeam = (team: Team, fieldsToUpdate: Partial<Team>): Team => {
   return {
     ...team,
     ...fieldsToUpdate


### PR DESCRIPTION
## Problem

Typo in code.


## Solution

`:` -> `,`

